### PR TITLE
Increase app_main stack size

### DIFF
--- a/FreeRTOS-Plus/Demo/app_main.c
+++ b/FreeRTOS-Plus/Demo/app_main.c
@@ -24,6 +24,10 @@
 extern int32_t socket_startup (void);
 extern void vStartSimpleMQTTDemo (void);
 
+static const osThreadAttr_t app_main_attr = {
+  .stack_size = 4096U
+};
+
 void vLoggingPrintf( const char * pcFormat,
                      ... )
 {
@@ -60,7 +64,7 @@ int app_main (void) {
 
   osKernelInitialize();
 
-  osThreadNew(app_main_thread, NULL, NULL);
+  osThreadNew(app_main_thread, NULL, &app_main_attr);
 
   osKernelStart();
   return 0;


### PR DESCRIPTION
The `socket_startup()` function, which initializes the MW-Network sockets, fails when using the default stack size because `netInitialize()` requires additional stack space. To resolve this, the stack size for `app_main_thread()` has been increased to 4 KB.
